### PR TITLE
fix: use style list to combine key styling for web

### DIFF
--- a/wordle-app/components/keyboard/index.tsx
+++ b/wordle-app/components/keyboard/index.tsx
@@ -31,12 +31,11 @@ const Key = ({
   return (
     <Pressable
       onPress={onPress}
-      style={{
-        ...styles.keyStyle,
+      style={[styles.keyStyle, {
         aspectRatio: 0.74 * width,
         width: keyWidth,
         backgroundColor: color,
-      }}
+      }]}
     >
       {typeof Letter === 'string' ? (
         <Text


### PR DESCRIPTION
before | after
--- | ---
![image](https://user-images.githubusercontent.com/1203991/153665993-b346539c-e303-4793-b2ac-2f9d15028a08.png) | ![image](https://user-images.githubusercontent.com/1203991/153666035-e769eaea-3b57-46c2-82f4-a154ebb207f3.png)
