### PR TITLE
chore: add auto-publish for both production and prs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize]
 
 concurrency:
-  group: preview-${{ github.ref }}
+  group: publish-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: publish
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    defaults:
+      run: 
+        working-directory: wordle-app
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v2
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: yarn
+          cache-dependency-path: wordle-app/yarn.lock
+
+      - name: 🏗 Setup Expo
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 📦 Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: 🚀 Publish production
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: expo publish --release-channel=production
+
+      - name: 🚀 Publish preview
+        if: ${{ github.event_name == 'pull_request' }}
+        run: expo publish --release-channel=pr-${{ github.event.number }}
+
+      - name: 💬 Comment preview
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: expo/expo-github-action/preview-comment@v7
+        with:
+          project: wordle-app
+          channel: pr-${{ github.event.number }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: 🚀 Publish production
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: expo publish --release-channel=production
+        run: expo publish --release-channel=main
 
       - name: 🚀 Publish preview
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
This adds auto-publishing to the repository, for both pushes to main and PRs.

Before merging this, the repo needs an `EXPO_TOKEN` secret to authenticate the Expo account to publish on. You can create one here: https://expo.dev/accounts/[account]/settings/access-tokens. I personally like to name the access tokens like the Github repo, e.g. `ccheever/expo-wordle`. 😄 